### PR TITLE
uint16_t definition lives in <stdint.h> these days

### DIFF
--- a/d8tape/d8tape.h
+++ b/d8tape/d8tape.h
@@ -25,6 +25,7 @@
 #define TAG_INDIRECTFC  0x0400              // target of an indirect flow control (JMS I / JMP I) (only meaningful if not writable)
 
 // segment info
+#include <stdint.h>
 
 typedef struct
 {


### PR DESCRIPTION
I've tested this on both glibc (Ubuntu 20.04) and musl-libc (Alpine Linux 3.15) so it seems to be pretty universal now.